### PR TITLE
add `RulesCfg` struct for deserialization, and related test cases

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,1 +1,26 @@
+use std::fmt::{Display, Formatter};
 
+#[derive(PartialEq, Debug)]
+/// Generic error types defining possible error outputs throughout this whole program.
+#[non_exhaustive]
+pub enum Error {
+    InvalidGuidelineID(String),
+    /// This is different than [`Error::InvalidGuidelineID`], this error should be
+    /// thrown when the type of a guideline is not a single character.
+    InvalidGuidelineType(String),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        use Error::*;
+        let msg = match self {
+            InvalidGuidelineID(id) => format!(
+                "'{id}' is not a valid guideline ID. A valid ID should looks like: \"G.Exam.Ple.01\""
+            ),
+            InvalidGuidelineType(ty) => format!(
+                "'{ty}' is not a valid guideline type. A valid type should be a single character such as 'P' or 'G'"
+            )
+        };
+        f.write_str(&msg)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod parser;
 pub mod utils;
 
 use anyhow::Result;
+pub use errors::Error;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod cli;
 mod errors;
-mod parser;
+pub mod parser;
 pub mod utils;
 
 use anyhow::Result;

--- a/src/parser/guideline.rs
+++ b/src/parser/guideline.rs
@@ -1,0 +1,135 @@
+//! This module contains definitions of CodingGuidelines related data.
+
+use crate::Error;
+use super::{Deserialize, de};
+use std::str::FromStr;
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct GuidelineID {
+    /// A character representing the type of this guideline,
+    /// such as 'P', 'G'.
+    pub ty: char,
+    /// The group where this guideline belongs,
+    /// such as "TYP.INT".
+    pub group: String,
+    /// The index of this guideline inside its group,
+    /// such as "01", "12".
+    pub idx: String,
+}
+
+impl FromStr for GuidelineID {
+    type Err = Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (maybe_ty, maybe_group_and_idx) = s
+            .split_once('.')
+            .ok_or(Error::InvalidGuidelineID(s.to_string()))?;
+        let ty = if maybe_ty.len() == 1 {
+            maybe_ty
+                .chars()
+                .next()
+                .expect("unexpected error when extracting type char from guideline ID")
+                .to_ascii_lowercase()
+        } else {
+            return Err(Error::InvalidGuidelineType(maybe_ty.to_string()));
+        };
+        let (group, idx) = maybe_group_and_idx
+            .rsplit_once('.')
+            .filter(|(g, i)| !g.is_empty() && !i.is_empty())
+            .map(|(g, i)| (g.to_ascii_lowercase(), i.to_string()))
+            .ok_or(Error::InvalidGuidelineID(s.to_string()))?;
+        Ok(GuidelineID { ty, group, idx })
+    }
+}
+
+impl ToString for GuidelineID {
+    fn to_string(&self) -> String {
+        format!("{}.{}.{}", self.ty, self.group, self.idx)
+    }
+}
+
+// Deserialize guideline ID with `FromStr` implementation.
+impl<'de> Deserialize<'de> for GuidelineID {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de> {
+        let s = String::deserialize(deserializer)?;
+        FromStr::from_str(&s).map_err(de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GuidelineID;
+
+    #[test]
+    fn good_guideline_id() {
+        let id_1 = "P.Exam.Ple.01".parse::<GuidelineID>();
+        let id_2 = "G.Typ.Arr.04".parse::<GuidelineID>();
+        let id_3 = "P.VAR.CONST.02".parse::<GuidelineID>();
+
+        assert_eq!(
+            id_1,
+            Ok(GuidelineID {
+                ty: 'p',
+                group: "exam.ple".to_string(),
+                idx: "01".to_string()
+            })
+        );
+        assert_eq!(
+            id_2,
+            Ok(GuidelineID {
+                ty: 'g',
+                group: "typ.arr".to_string(),
+                idx: "04".to_string()
+            })
+        );
+        assert_eq!(
+            id_3,
+            Ok(GuidelineID {
+                ty: 'p',
+                group: "var.const".to_string(),
+                idx: "02".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn guideline_id_with_various_length() {
+        let id_1 = "P.Exam.Ple.With.Various.Len.999".parse::<GuidelineID>();
+        let id_2 = "g.TEST.01".parse::<GuidelineID>();
+
+        assert_eq!(
+            id_1,
+            Ok(GuidelineID {
+                ty: 'p',
+                group: "exam.ple.with.various.len".to_string(),
+                idx: "999".to_string()
+            })
+        );
+        assert_eq!(
+            id_2,
+            Ok(GuidelineID {
+                ty: 'g',
+                group: "test".to_string(),
+                idx: "01".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn bad_guideline_id() {
+        // missing type (prefix)
+        let id_1 = ".Exam.Ple.01".parse::<GuidelineID>();
+        // missing index (postfix)
+        let id_2 = "P.typ.int.i32.".parse::<GuidelineID>();
+        // missing body
+        let id_3 = "P.P".parse::<GuidelineID>();
+        // type is not a single character
+        let id_4 = "Guide.Typ.Arr.04".parse::<GuidelineID>();
+
+        assert!(id_1.is_err());
+        assert!(id_2.is_err());
+        assert!(id_3.is_err());
+        assert!(id_4.is_err());
+    }
+}

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,2 +1,6 @@
 mod output_file;
 mod rules_config;
+
+use serde::Deserialize;
+
+pub use rules_config::*;

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,6 +1,7 @@
+mod guideline;
 mod output_file;
 mod rules_config;
 
-use serde::Deserialize;
+use serde::{Deserialize, de};
 
 pub use rules_config::*;

--- a/src/parser/rules_config.rs
+++ b/src/parser/rules_config.rs
@@ -1,129 +1,16 @@
 use super::Deserialize;
-use crate::Result;
-use anyhow::bail;
-use std::{collections::HashSet, path::Path};
+use std::collections::HashSet;
+use std::path::Path;
 
-pub trait ToolOpt<'ru> {
-    fn enabled(&self) -> bool;
-    fn compilation_opts(&self) -> Option<&'ru str>;
-}
-
-/// The configuration for checked rules.
+/// The user defined rules configuration.
+///
+/// User can specify which file to check, what compilation options to pass,
+/// and what guidelines the checks will be referenced.
 #[derive(Debug, Deserialize)]
 pub struct RulesCfg<'ru> {
     pub file_path: &'ru Path,
     #[serde(default)]
     pub supplement_compilation_options: Option<&'ru str>,
     #[serde(default)]
-    pub lints: Lints<'ru>,
-    #[serde(default)]
-    pub miri: Miri<'ru>,
-    #[serde(default)]
-    pub sanitizer: Sanitizer<'ru>,
-}
-
-#[derive(Debug, Deserialize, Default)]
-struct BasicToolOpt<'ru> {
-    enable: bool,
-    supplement_compilation_options: Option<&'ru str>,
-}
-
-/// Lint configurations, including clippy lints and rustc lints.
-#[derive(Debug, Deserialize, Default)]
-pub struct Lints<'ru> {
-    #[serde(borrow, flatten)]
-    opts: BasicToolOpt<'ru>,
-    pub clippy: LintsOpt<'ru>,
-    pub rustc: LintsOpt<'ru>,
-}
-
-/// Lints option.
-///
-/// Each group represent how the user want to handle the specified lints.
-// TODO: Add custome deserializer to prevent intersection, but right now,
-// we'll settle for calling a verifier method after deserializing is done.
-#[derive(Debug, Deserialize, Default, PartialEq)]
-pub struct LintsOpt<'ru> {
-    #[serde(borrow)]
-    pub deny: Vec<&'ru str>,
-    pub warn: Vec<&'ru str>,
-    pub allow: Vec<&'ru str>,
-}
-
-impl LintsOpt<'_> {
-    /// Verify the lints option to see if duplicate elements exist.
-    ///
-    /// For example, if user accidently wrote `clippy::all` in the deny list,
-    /// the wrote it again in the warn list. This doesn't considered as error by clippy or
-    /// rustc, but the result might differ due to which option gets passed at last.
-    /// So, this method is to prevent that situation.
-    pub fn verify(&self) -> Result<()> {
-        let mut all = Vec::new();
-        all.extend_from_slice(&self.deny);
-        all.extend_from_slice(&self.warn);
-        all.extend_from_slice(&self.allow);
-
-        let hs_all: HashSet<&str> = HashSet::from_iter(all.iter().cloned());
-
-        if all.len() != hs_all.len() {
-            bail!("Lints configuration contains duplicate elements");
-        }
-        Ok(())
-    }
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct Miri<'ru> {
-    #[serde(borrow, flatten)]
-    opts: BasicToolOpt<'ru>,
-}
-
-/// Supporting types of sanitizer,
-/// see [sanitizer doc](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
-/// for more information.
-#[derive(Debug, Deserialize, PartialEq)]
-pub enum SanitizerType {
-    Address,
-    Memory,
-    Leak,
-    Thread,
-}
-
-#[derive(Debug, Deserialize, Default)]
-pub struct Sanitizer<'ru> {
-    #[serde(borrow, flatten)]
-    opts: BasicToolOpt<'ru>,
-    #[serde(default = "default_sanitizer_types")]
-    /// A list of supporting sanitizers, as defined as [`SanitizerType`].
-    pub types: Vec<SanitizerType>,
-}
-
-fn default_sanitizer_types() -> Vec<SanitizerType> {
-    vec![SanitizerType::Address]
-}
-
-// TODO: these impls are redundent, use derive macros.
-impl<'ru> ToolOpt<'ru> for Lints<'ru> {
-    fn enabled(&self) -> bool {
-        self.opts.enable
-    }
-    fn compilation_opts(&self) -> Option<&'ru str> {
-        self.opts.supplement_compilation_options
-    }
-}
-impl<'ru> ToolOpt<'ru> for Miri<'ru> {
-    fn enabled(&self) -> bool {
-        self.opts.enable
-    }
-    fn compilation_opts(&self) -> Option<&'ru str> {
-        self.opts.supplement_compilation_options
-    }
-}
-impl<'ru> ToolOpt<'ru> for Sanitizer<'ru> {
-    fn enabled(&self) -> bool {
-        self.opts.enable
-    }
-    fn compilation_opts(&self) -> Option<&'ru str> {
-        self.opts.supplement_compilation_options
-    }
+    pub coding_guidelines: HashSet<&'ru str>,
 }

--- a/src/parser/rules_config.rs
+++ b/src/parser/rules_config.rs
@@ -2,6 +2,8 @@ use super::Deserialize;
 use std::collections::HashSet;
 use std::path::Path;
 
+use super::guideline::GuidelineID;
+
 /// The user defined rules configuration.
 ///
 /// User can specify which file to check, what compilation options to pass,
@@ -12,5 +14,5 @@ pub struct RulesCfg<'ru> {
     #[serde(default)]
     pub supplement_compilation_options: Option<&'ru str>,
     #[serde(default)]
-    pub coding_guidelines: HashSet<&'ru str>,
+    pub coding_guidelines: HashSet<GuidelineID>,
 }

--- a/src/parser/rules_config.rs
+++ b/src/parser/rules_config.rs
@@ -1,1 +1,129 @@
+use super::Deserialize;
+use crate::Result;
+use anyhow::bail;
+use std::{collections::HashSet, path::Path};
 
+pub trait ToolOpt<'ru> {
+    fn enabled(&self) -> bool;
+    fn compilation_opts(&self) -> Option<&'ru str>;
+}
+
+/// The configuration for checked rules.
+#[derive(Debug, Deserialize)]
+pub struct RulesCfg<'ru> {
+    pub file_path: &'ru Path,
+    #[serde(default)]
+    pub supplement_compilation_options: Option<&'ru str>,
+    #[serde(default)]
+    pub lints: Lints<'ru>,
+    #[serde(default)]
+    pub miri: Miri<'ru>,
+    #[serde(default)]
+    pub sanitizer: Sanitizer<'ru>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct BasicToolOpt<'ru> {
+    enable: bool,
+    supplement_compilation_options: Option<&'ru str>,
+}
+
+/// Lint configurations, including clippy lints and rustc lints.
+#[derive(Debug, Deserialize, Default)]
+pub struct Lints<'ru> {
+    #[serde(borrow, flatten)]
+    opts: BasicToolOpt<'ru>,
+    pub clippy: LintsOpt<'ru>,
+    pub rustc: LintsOpt<'ru>,
+}
+
+/// Lints option.
+///
+/// Each group represent how the user want to handle the specified lints.
+// TODO: Add custome deserializer to prevent intersection, but right now,
+// we'll settle for calling a verifier method after deserializing is done.
+#[derive(Debug, Deserialize, Default, PartialEq)]
+pub struct LintsOpt<'ru> {
+    #[serde(borrow)]
+    pub deny: Vec<&'ru str>,
+    pub warn: Vec<&'ru str>,
+    pub allow: Vec<&'ru str>,
+}
+
+impl LintsOpt<'_> {
+    /// Verify the lints option to see if duplicate elements exist.
+    ///
+    /// For example, if user accidently wrote `clippy::all` in the deny list,
+    /// the wrote it again in the warn list. This doesn't considered as error by clippy or
+    /// rustc, but the result might differ due to which option gets passed at last.
+    /// So, this method is to prevent that situation.
+    pub fn verify(&self) -> Result<()> {
+        let mut all = Vec::new();
+        all.extend_from_slice(&self.deny);
+        all.extend_from_slice(&self.warn);
+        all.extend_from_slice(&self.allow);
+
+        let hs_all: HashSet<&str> = HashSet::from_iter(all.iter().cloned());
+
+        if all.len() != hs_all.len() {
+            bail!("Lints configuration contains duplicate elements");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Miri<'ru> {
+    #[serde(borrow, flatten)]
+    opts: BasicToolOpt<'ru>,
+}
+
+/// Supporting types of sanitizer,
+/// see [sanitizer doc](https://doc.rust-lang.org/nightly/unstable-book/compiler-flags/sanitizer.html)
+/// for more information.
+#[derive(Debug, Deserialize, PartialEq)]
+pub enum SanitizerType {
+    Address,
+    Memory,
+    Leak,
+    Thread,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct Sanitizer<'ru> {
+    #[serde(borrow, flatten)]
+    opts: BasicToolOpt<'ru>,
+    #[serde(default = "default_sanitizer_types")]
+    /// A list of supporting sanitizers, as defined as [`SanitizerType`].
+    pub types: Vec<SanitizerType>,
+}
+
+fn default_sanitizer_types() -> Vec<SanitizerType> {
+    vec![SanitizerType::Address]
+}
+
+// TODO: these impls are redundent, use derive macros.
+impl<'ru> ToolOpt<'ru> for Lints<'ru> {
+    fn enabled(&self) -> bool {
+        self.opts.enable
+    }
+    fn compilation_opts(&self) -> Option<&'ru str> {
+        self.opts.supplement_compilation_options
+    }
+}
+impl<'ru> ToolOpt<'ru> for Miri<'ru> {
+    fn enabled(&self) -> bool {
+        self.opts.enable
+    }
+    fn compilation_opts(&self) -> Option<&'ru str> {
+        self.opts.supplement_compilation_options
+    }
+}
+impl<'ru> ToolOpt<'ru> for Sanitizer<'ru> {
+    fn enabled(&self) -> bool {
+        self.opts.enable
+    }
+    fn compilation_opts(&self) -> Option<&'ru str> {
+        self.opts.supplement_compilation_options
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,2 +1,5 @@
-pub mod filesystem;
-pub mod process;
+mod filesystem;
+mod process;
+
+pub use filesystem::*;
+pub use process::*;

--- a/tests/parse_rules_config.rs
+++ b/tests/parse_rules_config.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::collections::HashSet;
 
 use eunomia::parser::*;
 
@@ -29,14 +30,13 @@ fn de_normal_rules() {
     );
     assert_eq!(
         cfg.coding_guidelines,
-        [
-            "P.Exam.Ple.01",
-            "P.Exam.Ple.02",
-            "P.Exam.Ple.03",
-            "G.Exam.Ple.01",
-            "G.Exam.Ple.02",
-        ]
-        .into()
+        HashSet::from([
+            "P.Exam.Ple.01".parse().unwrap(),
+            "P.Exam.Ple.02".parse().unwrap(),
+            "P.Exam.Ple.03".parse().unwrap(),
+            "G.Exam.Ple.01".parse().unwrap(),
+            "G.Exam.Ple.02".parse().unwrap(),
+        ])
     );
 }
 

--- a/tests/parse_rules_config.rs
+++ b/tests/parse_rules_config.rs
@@ -8,31 +8,13 @@ fn de_normal_rules() {
 {
     "file_path": "./src/main.rs",
     "supplement_compilation_options": "-I../a/b/c/d sources=../e/f/g/h.rs",
-    "lints": {
-        "enable": true,
-        "supplement_compilation_options": "",
-        "clippy": {
-            "deny": [],
-            "warn": [
-                "all",
-                "pedantic"
-            ],
-            "allow": [ "cargo" ]
-        },
-        "rustc": {
-            "deny": [],
-            "warn": [],
-            "allow": []
-        }
-    },
-    "miri": {
-        "enable": true,
-        "supplement_compilation_options": ""
-    },
-    "sanitizer": {
-        "enable": true,
-        "supplement_compilation_options": ""
-    }
+    "coding_guidelines": [
+        "P.Exam.Ple.01",
+        "P.Exam.Ple.02",
+        "P.Exam.Ple.03",
+        "G.Exam.Ple.01",
+        "G.Exam.Ple.02"
+    ]
 }
 "#;
 
@@ -40,28 +22,22 @@ fn de_normal_rules() {
     assert!(test_cfg.is_ok());
 
     let cfg = test_cfg.unwrap();
-    let compilation_options = Some("");
     assert_eq!(cfg.file_path, Path::new("./src/main.rs"));
     assert_eq!(
         cfg.supplement_compilation_options,
         Some("-I../a/b/c/d sources=../e/f/g/h.rs")
     );
-    assert!(cfg.lints.enabled());
-    assert_eq!(cfg.lints.compilation_opts(), compilation_options);
     assert_eq!(
-        cfg.lints.clippy,
-        LintsOpt {
-            deny: Vec::new(),
-            warn: Vec::from(["all", "pedantic"]),
-            allow: Vec::from(["cargo"])
-        }
+        cfg.coding_guidelines,
+        [
+            "P.Exam.Ple.01",
+            "P.Exam.Ple.02",
+            "P.Exam.Ple.03",
+            "G.Exam.Ple.01",
+            "G.Exam.Ple.02",
+        ]
+        .into()
     );
-    assert_eq!(cfg.lints.rustc, LintsOpt::default());
-    assert!(cfg.miri.enabled());
-    assert!(cfg.sanitizer.enabled());
-    assert_eq!(cfg.miri.compilation_opts(), compilation_options);
-    assert_eq!(cfg.sanitizer.compilation_opts(), compilation_options);
-    assert_eq!(cfg.sanitizer.types, [SanitizerType::Address]);
 }
 
 #[test]
@@ -77,46 +53,16 @@ fn de_default_rules() {
     let cfg = test_cfg.unwrap();
     assert_eq!(cfg.file_path, Path::new("./src/main.rs"));
     assert!(cfg.supplement_compilation_options.is_none());
-    assert!(!cfg.lints.enabled());
-    assert!(cfg.lints.compilation_opts().is_none());
-    assert_eq!(cfg.lints.clippy, LintsOpt::default());
-    assert_eq!(cfg.lints.rustc, LintsOpt::default());
-    assert!(!cfg.miri.enabled());
-    assert!(!cfg.sanitizer.enabled());
-    assert!(cfg.miri.compilation_opts().is_none());
-    assert!(cfg.sanitizer.compilation_opts().is_none());
-    assert!(cfg.sanitizer.types.is_empty());
+    assert!(cfg.coding_guidelines.is_empty());
 }
 
 #[test]
-fn de_rules_with_duplicate_lints() {
+fn de_rules_missing_path() {
     let rule_str = r#"
     {
-        "file_path": "./src/main.rs",
-        "lints": {
-            "enable": true,
-            "clippy": {
-                "warn": [
-                    "all",
-                    "pedantic"
-                ],
-                "allow": [ "cargo" ],
-                "deny": [ "all" ]
-            },
-            "rustc": {
-                "deny": ["unused"],
-                "warn": ["all"],
-                "allow": []
-            }
-        }
-    }
-    "#;
+        "supplement_compilation_options": "-I../a/b/c/d sources=../e/f/g/h.rs"
+    }"#;
 
     let test_cfg: Result<RulesCfg, _> = serde_json::from_str(rule_str);
-    assert!(test_cfg.is_ok());
-    let cfg = test_cfg.unwrap();
-    // clippy lints option contains dup
-    assert!(cfg.lints.clippy.verify().is_err());
-    // rustc lints option does not contains dup
-    assert!(cfg.lints.rustc.verify().is_ok());
+    assert!(test_cfg.is_err());
 }

--- a/tests/parse_rules_config.rs
+++ b/tests/parse_rules_config.rs
@@ -1,0 +1,122 @@
+use std::path::Path;
+
+use eunomia::parser::*;
+
+#[test]
+fn de_normal_rules() {
+    let rule_input = r#"
+{
+    "file_path": "./src/main.rs",
+    "supplement_compilation_options": "-I../a/b/c/d sources=../e/f/g/h.rs",
+    "lints": {
+        "enable": true,
+        "supplement_compilation_options": "",
+        "clippy": {
+            "deny": [],
+            "warn": [
+                "all",
+                "pedantic"
+            ],
+            "allow": [ "cargo" ]
+        },
+        "rustc": {
+            "deny": [],
+            "warn": [],
+            "allow": []
+        }
+    },
+    "miri": {
+        "enable": true,
+        "supplement_compilation_options": ""
+    },
+    "sanitizer": {
+        "enable": true,
+        "supplement_compilation_options": ""
+    }
+}
+"#;
+
+    let test_cfg: Result<RulesCfg, _> = serde_json::from_str(rule_input);
+    assert!(test_cfg.is_ok());
+
+    let cfg = test_cfg.unwrap();
+    let compilation_options = Some("");
+    assert_eq!(cfg.file_path, Path::new("./src/main.rs"));
+    assert_eq!(
+        cfg.supplement_compilation_options,
+        Some("-I../a/b/c/d sources=../e/f/g/h.rs")
+    );
+    assert!(cfg.lints.enabled());
+    assert_eq!(cfg.lints.compilation_opts(), compilation_options);
+    assert_eq!(
+        cfg.lints.clippy,
+        LintsOpt {
+            deny: Vec::new(),
+            warn: Vec::from(["all", "pedantic"]),
+            allow: Vec::from(["cargo"])
+        }
+    );
+    assert_eq!(cfg.lints.rustc, LintsOpt::default());
+    assert!(cfg.miri.enabled());
+    assert!(cfg.sanitizer.enabled());
+    assert_eq!(cfg.miri.compilation_opts(), compilation_options);
+    assert_eq!(cfg.sanitizer.compilation_opts(), compilation_options);
+    assert_eq!(cfg.sanitizer.types, [SanitizerType::Address]);
+}
+
+#[test]
+fn de_default_rules() {
+    let rule_str = r#"
+{
+    "file_path": "./src/main.rs"
+}"#;
+
+    let test_cfg: Result<RulesCfg, _> = serde_json::from_str(rule_str);
+    assert!(test_cfg.is_ok());
+
+    let cfg = test_cfg.unwrap();
+    assert_eq!(cfg.file_path, Path::new("./src/main.rs"));
+    assert!(cfg.supplement_compilation_options.is_none());
+    assert!(!cfg.lints.enabled());
+    assert!(cfg.lints.compilation_opts().is_none());
+    assert_eq!(cfg.lints.clippy, LintsOpt::default());
+    assert_eq!(cfg.lints.rustc, LintsOpt::default());
+    assert!(!cfg.miri.enabled());
+    assert!(!cfg.sanitizer.enabled());
+    assert!(cfg.miri.compilation_opts().is_none());
+    assert!(cfg.sanitizer.compilation_opts().is_none());
+    assert!(cfg.sanitizer.types.is_empty());
+}
+
+#[test]
+fn de_rules_with_duplicate_lints() {
+    let rule_str = r#"
+    {
+        "file_path": "./src/main.rs",
+        "lints": {
+            "enable": true,
+            "clippy": {
+                "warn": [
+                    "all",
+                    "pedantic"
+                ],
+                "allow": [ "cargo" ],
+                "deny": [ "all" ]
+            },
+            "rustc": {
+                "deny": ["unused"],
+                "warn": ["all"],
+                "allow": []
+            }
+        }
+    }
+    "#;
+
+    let test_cfg: Result<RulesCfg, _> = serde_json::from_str(rule_str);
+    assert!(test_cfg.is_ok());
+    let cfg = test_cfg.unwrap();
+    // clippy lints option contains dup
+    assert!(cfg.lints.clippy.verify().is_err());
+    // rustc lints option does not contains dup
+    assert!(cfg.lints.rustc.verify().is_ok());
+}


### PR DESCRIPTION
implement #6

changelog: Add a `RulesCfg` struct and some other structure; Add tests cases for deserialize `RulesCfg`;