### PR TITLE
add implementation of generalized clippy output;

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = {version = "4.2.1", features = ["derive"] }
+regex = "1.7.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/parser/guideline.rs
+++ b/src/parser/guideline.rs
@@ -137,7 +137,7 @@ impl Serialize for GuidelineID {
 }
 
 /// Basic information about a guideline item, including its id and name.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct GuidelineSummary {
     pub id: GuidelineID,
     pub name: String,

--- a/src/parser/output_file.rs
+++ b/src/parser/output_file.rs
@@ -41,15 +41,15 @@ impl Output {
 // serialized, switch to builder pattern when derive macro is available in the future.
 #[derive(Debug, Serialize, Default)]
 pub struct CheckInfo {
-    pub file_path: PathBuf,
+    pub file_path: Option<PathBuf>,
     pub defect_name: String,
     pub tool: SupportedTool,
     pub begin_line: Option<usize>,
     pub end_line: Option<usize>,
     pub column: Option<usize>,
-    pub code_string: Option<String>,
-    pub help_info: Option<String>,
-    pub additional_help_info: Option<String>,
+    pub code_string: String,
+    pub help_info: String,
+    pub additional_help_info: String,
     pub guideline_list: Vec<GuidelineSummary>,
 }
 

--- a/src/tools/clippy.rs
+++ b/src/tools/clippy.rs
@@ -1,5 +1,9 @@
+use regex::Regex;
+
 use super::{Checker, Command, FilteredOutput};
+use crate::parser::CheckInfo;
 use crate::{utils, Result};
+use std::path::PathBuf;
 use std::process::Output;
 
 pub struct ClippyOpt<'c> {
@@ -16,7 +20,7 @@ impl Checker for ClippyOpt<'_> {
     fn check(&self) -> Result<Output> {
         utils::execute_for_output(self.cmd.app, self.cmd.args, self.cmd.envs.to_vec())
     }
-    fn filter_output(&self, output: &Output) -> FilteredOutput {
+    fn filter_output(output: &Output) -> FilteredOutput {
         // Clippy output is usually stderr type, so we keep stdout empty.
         let stdout = Vec::new();
 
@@ -44,5 +48,166 @@ impl Checker for ClippyOpt<'_> {
         }
 
         FilteredOutput { stdout, stderr }
+    }
+
+    /// Generalize clippy output to [`CheckInfo`] struct.
+    ///
+    /// Clippy output is contructed using similar fashion,
+    /// where the first line contains help information summary,
+    /// the line followed by '-->' contains source file location, start line and column number,
+    /// and following is the code, etc.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// let raw_result: "error: range is out of bounds
+    ///  --> src/clippy.rs:12:19
+    ///   |
+    ///12 |     let _ = &x[2..9];
+    ///   |                   ^
+    ///   |
+    ///   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#out_of_bounds_indexing
+    ///   = note: `#[deny(clippy::out_of_bounds_indexing)]` on by default"
+    ///
+    /// let info = ClippyOpt::check_info(raw_result).unwrap();
+    /// assert_eq!(info.help_info, Some("range is out of bounds".to_string()));
+    /// assert_eq!(info.defect_name, "out_of_bounds_indexing".to_string());
+    /// ```
+    fn check_info(raw_result: &str) -> Result<CheckInfo> {
+        let mut lines = raw_result.trim().lines();
+
+        // First line contains help message
+        let help_info = lines
+            .next()
+            .and_then(|s| s.split_once(':'))
+            .map_or(String::new(), |(_, msg)| msg.trim().to_string());
+
+        // Second line might contains position info
+        let (file_path, begin_line, column) = match lines.next().map(|s| {
+            s.trim()
+                .trim_start_matches("--> ")
+                .split(':')
+                .collect::<Vec<_>>()
+        }) {
+            Some(v) if v.len() == 3 => (
+                Some(PathBuf::from(v[0])),
+                v[1].trim().parse::<usize>().ok(),
+                v[2].trim().parse::<usize>().ok(),
+            ),
+            _ => (None, None, None),
+        };
+
+        // Handle the rest of lines
+        let mut code_string = String::new();
+        let mut extracted_info = ExtractedCheckInfo::default();
+        // regex to extract lint name from 'note: `#[warn(clippy::lint_name)]`'
+        let note_regex = Regex::new(r"clippy::(?P<name>(\w+))")?;
+        // regex to extract lint name from help message, which is from a url.
+        let help_regex = Regex::new(r"rust-clippy/master/index.html#(?P<name>(\w+))")?;
+        // A flag to mark whether the program is look for error code snippets or
+        // not, otherwise it's possible that a suggestion code will be mistaken as
+        // error code snippet.
+        let mut looking_for_code = true;
+
+        for line in lines {
+            let trimmed = line.trim();
+            // FIXME: this method is dumb, it's expensive and could cause false positive if
+            // a string variable has 'help: ' inside of it.
+            if trimmed.contains("help: ") {
+                looking_for_code = false;
+                update_info_from_help_or_note(trimmed, &help_regex, "help: ", &mut extracted_info);
+            } else if trimmed.contains("note: ") {
+                looking_for_code = false;
+                update_info_from_help_or_note(trimmed, &note_regex, "note: ", &mut extracted_info);
+            } else if looking_for_code {
+                if let Some(code) = maybe_code_line(trimmed) {
+                    code_string.push_str(code);
+                }
+            }
+        }
+
+        Ok(CheckInfo {
+            file_path,
+            defect_name: extracted_info.defect_name,
+            tool: super::SupportedTool::Clippy,
+            begin_line,
+            column,
+            code_string,
+            help_info,
+            additional_help_info: extracted_info.additional_help,
+            // FIXME: currently we haven't figured out a way to get the end line.
+            // TODO: get guideline relation map, and put them here.
+            ..Default::default()
+        })
+    }
+}
+
+#[derive(Default)]
+/// Subset of [`CheckInfo`], that could be extracted from 'help' and 'note' section
+/// of clippy output.
+struct ExtractedCheckInfo {
+    defect_name: String,
+    additional_help: String,
+}
+
+fn update_info_from_help_or_note(
+    line: &str,
+    re: &Regex,
+    split_by: &'static str,
+    info: &mut ExtractedCheckInfo,
+) {
+    if let Some(msg) = line.split_once(split_by).map(|(_, s)| s) {
+        info.additional_help.push_str(&format!("{msg}\n"));
+    }
+    if let Some(lint_name) = utils::regex_utils::get_named_match("name", re, line) {
+        info.defect_name = lint_name;
+    }
+}
+
+fn maybe_code_line(s: &str) -> Option<&str> {
+    if let Some((num, code)) = s.split_once('|') {
+        if num.trim().parse::<usize>().is_ok() {
+            return Some(code);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::utils::regex_utils;
+    use super::{maybe_code_line, Regex};
+
+    #[test]
+    fn test_extract_lint_name_from_note() {
+        let note_regex = Regex::new(r"clippy::(?P<name>(\w+))").unwrap();
+        let note_str = "= note: `#[warn(clippy::bool_comparison)]` on by default";
+
+        let name = regex_utils::get_named_match("name", &note_regex, note_str);
+        assert_eq!(name, Some("bool_comparison".to_string()));
+    }
+
+    #[test]
+    fn test_extract_lint_name_from_help() {
+        let help_regex = Regex::new(r"rust-clippy/master/index.html#(?P<name>(\w+))").unwrap();
+        let help_str = "= help: for further information visit \
+        https://rust-lang.github.io/rust-clippy/master/index.html#bool_comparison";
+
+        let name = regex_utils::get_named_match("name", &help_regex, help_str);
+        assert_eq!(name, Some("bool_comparison".to_string()));
+    }
+
+    #[test]
+    fn test_extract_code() {
+        let code_line_1 = "18 |     if flag == true {}";
+        let code_line_2 = "   |        ^^^^^^^^^^^^ help: try simplifying it as shown: `flag`";
+        let code_line_3 = "   |     ";
+
+        assert_eq!(
+            maybe_code_line(code_line_1),
+            Some("     if flag == true {}")
+        );
+        assert_eq!(maybe_code_line(code_line_2), None);
+        assert_eq!(maybe_code_line(code_line_3), None);
     }
 }

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -8,7 +8,7 @@ mod clippy;
 
 pub use self::clippy::ClippyOpt;
 
-use crate::Result;
+use crate::{parser::CheckInfo, Result};
 use std::{fmt::Display, process::Output, str::FromStr};
 
 /// Simple struct contains the name of executable, its args, and env vars in order
@@ -35,8 +35,16 @@ impl Display for Command<'_> {
 pub trait Checker {
     /// Get output by running commands.
     fn check(&self) -> Result<Output>;
-    /// Extract useful information from output.
-    fn filter_output(&self, output: &Output) -> FilteredOutput;
+    /// Extract only the useful information from output while splitting
+    /// them into different sections of multiple checking results.
+    ///
+    /// Note that the outputs are lossy `String` types, which is suitable
+    /// for printing. If you want a generalized output types,
+    /// implement [`Checker::check_info`] to interpret each output message
+    /// into a generalized [`CheckInfo`] type.
+    fn filter_output(output: &Output) -> FilteredOutput;
+    /// Generalize a string of output message to [`CheckInfo`] struct.
+    fn check_info(raw_result: &str) -> Result<CheckInfo>;
 }
 
 /// The output of a tool could have multiple sections of checked result,

--- a/src/utils/misc.rs
+++ b/src/utils/misc.rs
@@ -1,0 +1,7 @@
+pub mod regex_utils {
+    use regex::Regex;
+
+    pub fn get_named_match(name: &'static str, re: &Regex, s: &str) -> Option<String> {
+        re.captures_iter(s).next().map(|cap| cap[name].to_string())
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
 mod filesystem;
+mod misc;
 mod process;
 
 pub use filesystem::*;
+pub use misc::*;
 pub use process::*;

--- a/tests/output_result.rs
+++ b/tests/output_result.rs
@@ -5,14 +5,14 @@ use std::path::PathBuf;
 #[test]
 fn se_check_info_single_entity() {
     let check_info_list = vec![CheckInfo {
-        file_path: PathBuf::from("./src/main.rs"),
+        file_path: Some(PathBuf::from("./src/main.rs")),
         tool: SupportedTool::Clippy,
         defect_name: "exhaustive_enums".to_string(),
         begin_line: Some(15),
         column: Some(23),
-        code_string: Some(String::new()),
-        help_info: Some(String::new()),
-        additional_help_info: Some(String::new()),
+        code_string: String::new(),
+        help_info: String::new(),
+        additional_help_info: String::new(),
         guideline_list: vec![GuidelineSummary {
             id: "P.VAR.01".parse().unwrap(),
             name: "ssss".to_string(),
@@ -54,26 +54,26 @@ fn se_check_info_single_entity() {
 fn se_check_info_multiple_entities() {
     let check_info_list = vec![
         CheckInfo {
-            file_path: PathBuf::from("./src/main.rs"),
+            file_path: Some(PathBuf::from("./src/main.rs")),
             tool: SupportedTool::Clippy,
             defect_name: "exhaustive_enums".to_string(),
             begin_line: Some(15),
             end_line: Some(18),
             column: Some(23),
-            code_string: Some("xxx {\n\n\n xxa }".to_string()),
-            help_info: Some(String::new()),
-            additional_help_info: Some(String::new()),
+            code_string: "xxx {\n\n\n xxa }".to_string(),
+            help_info: String::new(),
+            additional_help_info: String::new(),
             guideline_list: vec![GuidelineSummary {
                 id: "P.VAR.01".parse().unwrap(),
                 name: "ssss".to_string(),
             }],
         },
         CheckInfo {
-            file_path: PathBuf::from("./src/lib.rs"),
+            file_path: Some(PathBuf::from("./src/lib.rs")),
             defect_name: "dead_code".to_string(),
             begin_line: Some(20),
             column: Some(8),
-            code_string: Some("let x = 1;".to_string()),
+            code_string: "let x = 1;".to_string(),
             guideline_list: vec![
                 GuidelineSummary {
                     id: "g.exam.ple.01".parse().unwrap(),
@@ -87,7 +87,7 @@ fn se_check_info_multiple_entities() {
             ..Default::default()
         },
         CheckInfo {
-            file_path: PathBuf::from("./src/something.rs"),
+            file_path: Some(PathBuf::from("./src/something.rs")),
             defect_name: "memory_leak".to_string(),
             tool: SupportedTool::Sanitizer,
             guideline_list: vec![GuidelineSummary {
@@ -125,8 +125,8 @@ fn se_check_info_multiple_entities() {
       "end_line": null,
       "column": 8,
       "code_string": "let x = 1;",
-      "help_info": null,
-      "additional_help_info": null,
+      "help_info": "",
+      "additional_help_info": "",
       "guideline_list": [
         {
           "id": "g.exam.ple.01",
@@ -145,9 +145,9 @@ fn se_check_info_multiple_entities() {
       "begin_line": null,
       "end_line": null,
       "column": null,
-      "code_string": null,
-      "help_info": null,
-      "additional_help_info": null,
+      "code_string": "",
+      "help_info": "",
+      "additional_help_info": "",
       "guideline_list": [
         {
           "id": "g.exam.ple.03",
@@ -180,15 +180,15 @@ fn se_empty_check_info() {
     let expected_json = r#"{
   "check_info": [
     {
-      "file_path": "",
+      "file_path": null,
       "defect_name": "",
       "tool": "rustc",
       "begin_line": null,
       "end_line": null,
       "column": null,
-      "code_string": null,
-      "help_info": null,
-      "additional_help_info": null,
+      "code_string": "",
+      "help_info": "",
+      "additional_help_info": "",
       "guideline_list": []
     }
   ]

--- a/tests/tools/clippy.rs
+++ b/tests/tools/clippy.rs
@@ -1,6 +1,24 @@
 use super::mock_dir;
-use eunomia::tools::*;
-use std::env::set_current_dir;
+use eunomia::{parser::CheckInfo, tools::*};
+use std::{env::set_current_dir, path::PathBuf};
+
+/// Manually compare two check info, without the need of impl PartialEq for the entire
+/// struct just for the sake of tests, and provide more details in which member doesn't match.
+fn assert_eq_check_info(lhs: &CheckInfo, rhs: &CheckInfo) {
+    assert_eq!(lhs.file_path, rhs.file_path, "file_path");
+    assert_eq!(lhs.begin_line, rhs.begin_line, "begin_line");
+    assert_eq!(lhs.end_line, rhs.end_line, "end_line");
+    assert_eq!(lhs.column, rhs.column, "column");
+    assert_eq!(lhs.defect_name, rhs.defect_name, "defect_name");
+    assert_eq!(lhs.help_info, rhs.help_info, "help_info");
+    assert_eq!(
+        lhs.additional_help_info, rhs.additional_help_info,
+        "additional_help_info"
+    );
+    assert_eq!(lhs.code_string, rhs.code_string, "code_string");
+    assert_eq!(lhs.tool, rhs.tool, "tool");
+    assert_eq!(lhs.guideline_list, rhs.guideline_list, "guideline_list");
+}
 
 #[test]
 fn clippy_default() {
@@ -14,7 +32,7 @@ fn clippy_default() {
     let clippy_opt = ClippyOpt::from_command(cmd);
 
     let output = clippy_opt.check().unwrap();
-    let mut filtered = clippy_opt.filter_output(&output);
+    let mut filtered = ClippyOpt::filter_output(&output);
 
     filtered.stderr.sort();
     let expected_output = vec![
@@ -72,4 +90,51 @@ r#"warning: comparison to empty slice
 
     assert_eq!(filtered.stdout, Vec::<String>::new());
     assert_eq!(filtered.stderr, expected_output);
+}
+
+#[test]
+fn clippy_unified_output() {
+    let output_1 = "error: range is out of bounds
+  --> src/clippy.rs:12:19
+   |
+12 |     let _ = &x[2..9];
+   |                   ^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#out_of_bounds_indexing
+   = note: `#[deny(clippy::out_of_bounds_indexing)]` on by default";
+
+    let info = ClippyOpt::check_info(output_1).unwrap();
+
+    let expected = CheckInfo {
+      file_path: Some(PathBuf::from("src/clippy.rs")),
+      tool: SupportedTool::Clippy,
+      begin_line: Some(12),
+      column: Some(19),
+      help_info: "range is out of bounds".to_string(),
+      defect_name: "out_of_bounds_indexing".to_string(),
+      code_string: "     let _ = &x[2..9];".to_string(),
+      additional_help_info: "for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#out_of_bounds_indexing
+`#[deny(clippy::out_of_bounds_indexing)]` on by default\n".to_string(),
+      ..Default::default()
+   };
+
+    assert_eq_check_info(&info, &expected);
+}
+
+#[test]
+fn clippy_unified_output_short() {
+    let output_1 = "warning: package `mock` is missing `package.categories` metadata
+  |
+  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata";
+
+    let info = ClippyOpt::check_info(output_1).unwrap();
+
+    let expected = CheckInfo {
+      tool: SupportedTool::Clippy,
+      help_info: "package `mock` is missing `package.categories` metadata".to_string(),
+      defect_name: "cargo_common_metadata".to_string(),
+      additional_help_info: "for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cargo_common_metadata\n".to_string(),
+      ..Default::default()
+   };
+    assert_eq_check_info(&info, &expected);
 }


### PR DESCRIPTION
#11 
#12 

changelog:
- add implementation of generalized clippy output;
- add regex as dependency;
- change CheckInfo's code_string, help, additional_help messages from `Option<String>` to `String`;